### PR TITLE
add bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "WPGulp",
+  "description": "Gulp with WordPress. Start using Gulp with your WordPress plugins and themes.",
+  "main": "gulpfile.js",
+  "license": "MIT",
+  "keywords": [
+    "gulp",
+    "js",
+    "workflow",
+    "wordpress"
+  ],
+  "homepage": "https://github.com/ahmadawais/WPGulp",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Already added to following endpoints for [bower.io](http://bower.io):

* wpgulp
* wp-gulp
* WPGulp

For info:

``` shell
$ bower info wpgulp
$ bower info wp-gulp
$ bower info WPGulp
```

To install:

``` shell
$ bower install wpgulp
$ bower install wp-gulp
$ bower install WPGulp
```