### PR TITLE
Updates destination for gulp-wp-pot to destFile.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -306,7 +306,7 @@ gulp.task( 'browser-sync', function() {
              lastTranslator: lastTranslator,
              team          : team
          } ))
-        .pipe(gulp.dest(translatePath))
+        .pipe(gulp.dest(destFile))
         .pipe( notify( { message: 'TASK: "translate" Completed! 💯', onLast: true } ) )
 
  });


### PR DESCRIPTION
Updates destination for gulp-wp-pot to destFile instead of translatePath due to changes in the gulp-wp-pot project.
Closes #34 