### PR TITLE
feat: add es6 support via gulp-uglify-es

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,7 +103,7 @@ var mmq          = require('gulp-merge-media-queries'); // Combine matching medi
 
 // JS related plugins.
 var concat       = require('gulp-concat'); // Concatenates JS files
-var uglify       = require('gulp-uglify'); // Minifies JS files
+var uglify       = require('gulp-uglify-es').default; // Minifies JS files
 
 // Image realted plugins.
 var imagemin     = require('gulp-imagemin'); // Minify PNG, JPEG, GIF and SVG images with imagemin.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "gulp-rename": "^1.2.0",
     "gulp-sass": "^2.2.0",
     "gulp-sourcemaps": "^1.5.2",
-    "gulp-uglify": "^1.5.3",
+    "gulp-uglify-es": "^0.1.3",
     "gulp-uglifycss": "^1.0.6",
     "gulp-sort": "^2.0.0",
     "gulp-wp-pot": "^1.2.2"


### PR DESCRIPTION
use [gulp-uglify-es](https://www.npmjs.com/package/gulp-uglify-es) instead of regular [gulp-uglify](https://github.com/terinjokes/gulp-uglify) as stated in the [README](https://github.com/mishoo/UglifyJS2#note) in order to enable support for es6+ minification.

fixes #53 