### PR TITLE
Fix incorrect sourcemap destination

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -184,7 +184,7 @@ gulp.task( 'browser-sync', function() {
     .pipe( sourcemaps.init( { loadMaps: true } ) )
     .pipe( autoprefixer( AUTOPREFIXER_BROWSERS ) )
 
-    .pipe( sourcemaps.write ( styleDestination ) )
+    .pipe( sourcemaps.write ( './' ) )
     .pipe( lineec() ) // Consistent Line Endings for non UNIX systems.
     .pipe( gulp.dest( styleDestination ) )
 


### PR DESCRIPTION
According to the [documentation](https://github.com/gulp-sourcemaps/gulp-sourcemaps#write-external-source-map-files):

> To write external source map files, pass a path __relative to the destination__ to `sourcemaps.write()`.

In WPGulp, however, there is this: 

```
.pipe( sourcemaps.write ( styleDestination ) )
.pipe( lineec() ) // Consistent Line Endings for non UNIX systems.
.pipe( gulp.dest( styleDestination ) )
```

which, if `styleDestination` is set to `'./dist/'`, effectively creates this structure: 
```
dist/
├── dist/
│   └── style.css.map
└── style.css
```
(notice the double `dist/`)

I've fixed this by setting the write destination to proper - current folder.