### PR TITLE
Update Project to Utilize Gulp 4

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -274,7 +274,7 @@ gulp.task( 'browser-sync', function() {
   * again, do it with the command `gulp images`.
   */
  gulp.task( 'images', function() {
-  gulp.src( imagesSRC )
+  return gulp.src( imagesSRC )
     .pipe( imagemin( {
           progressive: true,
           optimizationLevel: 3, // 0-7 low-high

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -118,6 +118,9 @@ var browserSync  = require('browser-sync').create(); // Reloads browser and inje
 var reload       = browserSync.reload; // For manual browser reload.
 var wpPot        = require('gulp-wp-pot'); // For generating the .pot file.
 var sort         = require('gulp-sort'); // Recommended to prevent unnecessary changes in pot-file.
+var cached 		 = require('gulp-cached'); // Cache files in stream for later use
+var remember 	 = require('gulp-remember'); // Restore files from stream cache
+
 
 /**
  * Task: `browser-sync`.
@@ -218,7 +221,7 @@ gulp.task( 'browser-sync', function() {
   *     4. Uglifes/Minifies the JS file and generates vendors.min.js
   */
  gulp.task( 'vendorsJs', function() {
-  return gulp.src( jsVendorSRC )
+  return gulp.src( jsVendorSRC, { since: gulp.lastRun('vendorsJs') } )
     .pipe( concat( jsVendorFile + '.js' ) )
     .pipe( lineec() ) // Consistent Line Endings for non UNIX systems.
     .pipe( gulp.dest( jsVendorDestination ) )

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -169,7 +169,7 @@ gulp.task( 'browser-sync', function() {
  *    7. Injects CSS or reloads the browser via browserSync
  */
  gulp.task('styles', function () {
-    gulp.src( styleSRC )
+  return gulp.src( styleSRC )
     .pipe( sourcemaps.init() )
     .pipe( sass( {
       errLogToConsole: true,
@@ -204,7 +204,7 @@ gulp.task( 'browser-sync', function() {
     .pipe( browserSync.stream() )// Reloads style.min.css if that is enqueued.
     .pipe( notify( { message: 'TASK: "styles" Completed! 💯', onLast: true } ) )
  });
-
+ 
 
  /**
   * Task: `vendorJS`.
@@ -218,7 +218,7 @@ gulp.task( 'browser-sync', function() {
   *     4. Uglifes/Minifies the JS file and generates vendors.min.js
   */
  gulp.task( 'vendorsJs', function() {
-  gulp.src( jsVendorSRC )
+  return gulp.src( jsVendorSRC )
     .pipe( concat( jsVendorFile + '.js' ) )
     .pipe( lineec() ) // Consistent Line Endings for non UNIX systems.
     .pipe( gulp.dest( jsVendorDestination ) )

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -317,9 +317,9 @@ gulp.task( 'browser-sync', function() {
   *
   * Watches for file changes and runs specific tasks.
   */
- gulp.task( 'default', ['styles', 'vendorsJs', 'customJS', 'images', 'browser-sync'], function () {
+ gulp.task( 'default', gulp.parallel('styles', 'vendorsJs', 'customJS', 'images', 'browser-sync', function () {
   gulp.watch( projectPHPWatchFiles, reload ); // Reload on PHP file changes.
-  gulp.watch( styleWatchFiles, [ 'styles' ] ); // Reload on SCSS file changes.
-  gulp.watch( vendorJSWatchFiles, [ 'vendorsJs', reload ] ); // Reload on vendorsJs file changes.
-  gulp.watch( customJSWatchFiles, [ 'customJS', reload ] ); // Reload on customJS file changes.
- });
+  gulp.watch( styleWatchFiles, gulp.parallel( 'styles' ) ); // Reload on SCSS file changes.
+  gulp.watch( vendorJSWatchFiles, gulp.parallel( 'vendorsJs', reload ) ); // Reload on vendorsJs file changes.
+  gulp.watch( customJSWatchFiles, gulp.parallel( 'customJS', reload ) ); // Reload on customJS file changes.
+ }));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -245,7 +245,7 @@ gulp.task( 'browser-sync', function() {
   *     4. Uglifes/Minifies the JS file and generates custom.min.js
   */
  gulp.task( 'customJS', function() {
-    gulp.src( jsCustomSRC )
+   return gulp.src( jsCustomSRC )
     .pipe( concat( jsCustomFile + '.js' ) )
     .pipe( lineec() ) // Consistent Line Endings for non UNIX systems.
     .pipe( gulp.dest( jsCustomDestination ) )

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -132,7 +132,7 @@ var remember 	 = require('gulp-remember'); // Restore files from stream cache
  *    3. You may define a custom port
  *    4. You may want to stop the browser from openning automatically
  */
-gulp.task( 'browser-sync', function() {
+function browsersync() {
   browserSync.init( {
 
     // For more options
@@ -153,7 +153,7 @@ gulp.task( 'browser-sync', function() {
     // port: 7000,
 
   } );
-});
+};
 
 // Helper function to allow browser reload with Gulp 4
 function reload(done) {
@@ -325,7 +325,7 @@ function reload(done) {
   *
   * Watches for file changes and runs specific tasks.
   */
- gulp.task( 'default', gulp.parallel('styles', 'vendorsJs', 'customJS', 'images', 'browser-sync', function () {
+ gulp.task( 'default', gulp.parallel('styles', 'vendorsJs', 'customJS', 'images', browsersync, function () {
   gulp.watch( projectPHPWatchFiles, reload ); // Reload on PHP file changes.
   gulp.watch( styleWatchFiles, gulp.parallel( 'styles' ) ); // Reload on SCSS file changes.
   gulp.watch( vendorJSWatchFiles, gulp.series( 'vendorsJs', reload ) ) // Reload on vendorsJs file changes.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,7 @@
 // START Editing Project Variables.
 // Project related.
 var project                 = 'WPGulpTheme'; // Project Name.
-var projectURL              = 'wpgulp.dev'; // Local project URL of your already running WordPress site. Could be something like local.dev or localhost:8888.
+var projectURL              = 'localhost:8888'; // Local project URL of your already running WordPress site. Could be something like local.dev or localhost:8888.
 var productURL              = './'; // Theme/Plugin URL. Leave it like it is, since our gulpfile.js lives in the root folder.
 
 // Translation related.
@@ -115,7 +115,6 @@ var filter       = require('gulp-filter'); // Enables you to work on a subset of
 var sourcemaps   = require('gulp-sourcemaps'); // Maps code in a compressed file (E.g. style.css) back to it’s original position in a source file (E.g. structure.scss, which was later combined with other css files to generate style.css)
 var notify       = require('gulp-notify'); // Sends message notification to you
 var browserSync  = require('browser-sync').create(); // Reloads browser and injects CSS. Time-saving synchronised browser testing.
-var reload       = browserSync.reload; // For manual browser reload.
 var wpPot        = require('gulp-wp-pot'); // For generating the .pot file.
 var sort         = require('gulp-sort'); // Recommended to prevent unnecessary changes in pot-file.
 var cached 		 = require('gulp-cached'); // Cache files in stream for later use
@@ -155,6 +154,12 @@ gulp.task( 'browser-sync', function() {
 
   } );
 });
+
+// Helper function to allow browser reload with Gulp 4
+function reload(done) {
+  browserSync.reload();
+  done();
+}
 
 
 /**
@@ -221,7 +226,7 @@ gulp.task( 'browser-sync', function() {
   *     4. Uglifes/Minifies the JS file and generates vendors.min.js
   */
  gulp.task( 'vendorsJs', function() {
-  return gulp.src( jsVendorSRC, { since: gulp.lastRun('vendorsJs') } )
+  return gulp.src( jsVendorSRC )
     .pipe( concat( jsVendorFile + '.js' ) )
     .pipe( lineec() ) // Consistent Line Endings for non UNIX systems.
     .pipe( gulp.dest( jsVendorDestination ) )
@@ -323,6 +328,6 @@ gulp.task( 'browser-sync', function() {
  gulp.task( 'default', gulp.parallel('styles', 'vendorsJs', 'customJS', 'images', 'browser-sync', function () {
   gulp.watch( projectPHPWatchFiles, reload ); // Reload on PHP file changes.
   gulp.watch( styleWatchFiles, gulp.parallel( 'styles' ) ); // Reload on SCSS file changes.
-  gulp.watch( vendorJSWatchFiles, gulp.parallel( 'vendorsJs', reload ) ); // Reload on vendorsJs file changes.
-  gulp.watch( customJSWatchFiles, gulp.parallel( 'customJS', reload ) ); // Reload on customJS file changes.
+  gulp.watch( vendorJSWatchFiles, gulp.series( 'vendorsJs', reload ) ) // Reload on vendorsJs file changes.
+  gulp.watch( customJSWatchFiles, gulp.series( 'customJS', reload ) ); // Reload on customJS file changes.
  }));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,7 @@
 // START Editing Project Variables.
 // Project related.
 var project                 = 'WPGulpTheme'; // Project Name.
-var projectURL              = 'localhost:8888'; // Local project URL of your already running WordPress site. Could be something like local.dev or localhost:8888.
+var projectURL              = 'wpgulp.local'; // Local project URL of your already running WordPress site. Could be something like local.dev or localhost:8888.
 var productURL              = './'; // Theme/Plugin URL. Leave it like it is, since our gulpfile.js lives in the root folder.
 
 // Translation related.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {},
   "devDependencies": {
     "browser-sync": "^2.11.1",
-    "gulp": "^3.9.1",
+    "gulp": "github:gulpjs/gulp#4.0",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-concat": "^2.5.2",
     "gulp-filter": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -12,18 +12,20 @@
     "browser-sync": "^2.11.1",
     "gulp": "github:gulpjs/gulp#4.0",
     "gulp-autoprefixer": "^3.1.0",
+    "gulp-cached": "^1.1.1",
     "gulp-concat": "^2.5.2",
     "gulp-filter": "^4.0.0",
     "gulp-imagemin": "^2.4.0",
     "gulp-line-ending-corrector": "^1.0.1",
     "gulp-merge-media-queries": "^0.2.1",
     "gulp-notify": "^2.2.0",
+    "gulp-remember": "^1.0.0",
     "gulp-rename": "^1.2.0",
     "gulp-sass": "^2.2.0",
+    "gulp-sort": "^2.0.0",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.5.3",
     "gulp-uglifycss": "^1.0.6",
-    "gulp-sort": "^2.0.0",
     "gulp-wp-pot": "^1.2.2"
   }
 }


### PR DESCRIPTION
This pull request aims to simply update this project to utilize Gulp 4 - meaning the project should work exactly as before. No changes were made beyond updating the project to Gulp 4. I wanted to get this change up ASAP so all future changes can be tested using Gulp 4.

Some notes about the changes:

- We not utilize `gulp.parallel` for tasks that need to run at the same time and `gulp.series` for tasks that run one after the other.
- Browsersync was converted to a function instead of a task. As we do not call `gulp browsersync` directly, it does not (and should not) be setup as a task.
- Streams must explicitly mark they have ended. We do this by using a `return` at the top of tasks. 

If anyone has any questions, concerns or better ways of handling this, please let me know!  