### PR TITLE
FIX: Translation destination 💯

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -300,13 +300,12 @@ gulp.task( 'browser-sync', function() {
          .pipe(sort())
          .pipe(wpPot( {
              domain        : text_domain,
-             destFile      : translationFile,
              package       : packageName,
              bugReport     : bugReport,
              lastTranslator: lastTranslator,
              team          : team
          } ))
-        .pipe(gulp.dest(translationDestination))
+        .pipe(gulp.dest(translationDestination + '/' + translationFile ))
         .pipe( notify( { message: 'TASK: "translate" Completed! 💯', onLast: true } ) )
 
  });


### PR DESCRIPTION
There is a bug causing the translation to be saved in the wrong location and file name. ‘languages’ instead of languages/WPGULP.pot. This is a fix.