### PR TITLE
FIX: Spellings of `comment`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,7 +83,7 @@ function browsersync() {
 		open: config.browserAutoOpen,
 
 		// Inject CSS changes.
-		// Commnet it to reload browser for every CSS change.
+		// Comment it to reload browser for every CSS change.
 		injectChanges: config.injectChanges
 	});
 


### PR DESCRIPTION
## Description
Fix the spellings of `comment` from `commnet` to `comment`.

## Screenshot:
![commit screensho](https://user-images.githubusercontent.com/31374163/34693701-89c494bc-f4e6-11e7-8c94-10f4b3574734.png)


## Types of changes
FIX: spellings mistake

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has extensive inline documentation like the rest of WPGulp.