### PR TITLE
IMPROVE: Remove Gulp Global Dependency by using NPM Scripts

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -254,6 +254,16 @@ gulp.task( 'images', function() {
 });
 
 /**
+ * Task: `clear-images-cache`.
+ *
+ * Deletes the images cache. By running the next "images" task,
+ * each image will be regenerated.
+ */
+gulp.task( 'clearCache', function( done ) {
+	return cache.clearAll( done );
+});
+
+/**
  * WP POT Translation File Generator.
  *
  * * This task does the following:
@@ -283,16 +293,6 @@ gulp.task( 'translate', function() {
 				onLast: true
 			})
 		);
-});
-
-/**
- * Task: `clear-images-cache`.
- *
- * Deletes the images cache. By running the next "images" task,
- * each image will be regenerated.
- */
-gulp.task( 'clearCache', function( done ) {
-	return cache.clearAll( done );
 });
 
 /**

--- a/package.json
+++ b/package.json
@@ -32,5 +32,15 @@
     "gulp-uglify": "^3.0.0",
     "gulp-uglifycss": "^1.0.6",
     "gulp-wp-pot": "^2.0.7"
+  },
+  "scripts": {
+    "postinstall": "npm run start",
+    "start": "gulp",
+    "styles": "gulp styles",
+    "vendorsJS": "gulp vendorsJS",
+    "customJS": "gulp customJS",
+    "images": "gulp images",
+    "clearCache": "gulp clearCache",
+    "translate": "gulp translate"
   }
 }


### PR DESCRIPTION
<!-- Make the Pull Requests against v2.0.0 branch if possible -->
<!-- Start the commit message/title only with these three words -->
 <!-- "FIX: ", "NEW: ", "IMPROVE: " — all caps (only the first word and not the rest of the title). -->
## Description <!-- Kindly describe your changes -->
Added NPM scripts to package.json so users do not have to install Gulp globally.

## Screenshots: <!-- JPEG or GIFs are always helpful -->
![screen shot 2018-01-13 at 4 43 36 pm](https://user-images.githubusercontent.com/6110968/34911154-1f947b7c-f881-11e7-9c49-4c0f0b5bf8b7.png)

![screen shot 2018-01-13 at 4 45 59 pm](https://user-images.githubusercontent.com/6110968/34911157-47048b66-f881-11e7-9ef9-fb6436c4a6a9.png)

![screen shot 2018-01-13 at 4 46 49 pm](https://user-images.githubusercontent.com/6110968/34911163-83bc2226-f881-11e7-8b7e-84fcb41c2cad.png)

![screen shot 2018-01-13 at 4 48 19 pm](https://user-images.githubusercontent.com/6110968/34911171-d14be5ee-f881-11e7-82c1-689da10472d6.png)

![screen shot 2018-01-13 at 4 48 52 pm](https://user-images.githubusercontent.com/6110968/34911172-d36ed642-f881-11e7-92a9-d1bca4bab5ca.png)

![screen shot 2018-01-13 at 4 49 13 pm](https://user-images.githubusercontent.com/6110968/34911173-d6d11782-f881-11e7-9e15-e7020224d5e6.png)

![screen shot 2018-01-13 at 4 49 50 pm](https://user-images.githubusercontent.com/6110968/34911174-dfee497a-f881-11e7-837b-48bbc15c8615.png)

## Types of changes
Tasks must be run using `npm run taskName`.

- `gulp` becomes `npm run start`
- `gulp styles` becomes `npm run styles`
- `gulp vendorsJS` becomes `npm run vendorsJS`
- `gulp customJS` becomes `npm run customJS`
- `gulp images` becomes `npm run images`
- `gulp clearCache` becomes `npm run clearCache`
- `gulp translate` becomes `npm run translate`

## How Has This Been Tested?
Each task was run using the new `npm run` format. Screenshots can be seen above.


## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has extensive inline documentation like the rest of WPGulp.