### PR TITLE
NEW: Add Caching to JS Tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,7 +60,6 @@ var sort = require( 'gulp-sort' ); // Recommended to prevent unnecessary changes
 var cache = require( 'gulp-cache' ); // Cache files in stream for later use
 var remember = require( 'gulp-remember' ); //  Adds all the files it has ever seen back into the stream
 
-
 /**
  * Task: `browser-sync`.
  *
@@ -154,9 +153,8 @@ gulp.task( 'styles', function() {
  *     3. Renames the JS file with suffix .min.js
  *     4. Uglifes/Minifies the JS file and generates vendors.min.js
  */
-
 gulp.task( 'vendorsJS', function() {
-	return gulp.src( config.jsVendorSRC, {since: gulp.lastRun( 'vendorsJS' ) } )
+	return gulp.src( config.jsVendorSRC, {since: gulp.lastRun( 'vendorsJS' ) } ) // Only run on changed files
 		.pipe(
 			babel({
 				presets: [
@@ -196,7 +194,7 @@ gulp.task( 'vendorsJS', function() {
  *     4. Uglifes/Minifies the JS file and generates custom.min.js
  */
 gulp.task( 'customJS', function() {
-	return gulp.src( config.jsCustomSRC )
+	return gulp.src( config.jsCustomSRC, {since: gulp.lastRun( 'customJS' ) } ) // Only run on changed files
 		.pipe(
 	 		babel({
 				presets: [
@@ -208,6 +206,7 @@ gulp.task( 'customJS', function() {
 				]
 			})
 		)
+		.pipe( remember( 'customJS' ) ) // Bring all files back to stream
 		.pipe( concat( config.jsCustomFile + '.js' ) )
 		.pipe( lineec() ) // Consistent Line Endings for non UNIX systems.
 		.pipe( gulp.dest( config.jsCustomDestination ) )

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -154,7 +154,7 @@ gulp.task( 'styles', function() {
  *     4. Uglifes/Minifies the JS file and generates vendors.min.js
  */
 gulp.task( 'vendorsJS', function() {
-	return gulp.src( config.jsVendorSRC, {since: gulp.lastRun( 'vendorsJS' ) } ) // Only run on changed files
+	return gulp.src( config.jsVendorSRC, {since: gulp.lastRun( 'vendorsJS' ) } ) // Only run on changed files.
 		.pipe(
 			babel({
 				presets: [
@@ -194,7 +194,7 @@ gulp.task( 'vendorsJS', function() {
  *     4. Uglifes/Minifies the JS file and generates custom.min.js
  */
 gulp.task( 'customJS', function() {
-	return gulp.src( config.jsCustomSRC, {since: gulp.lastRun( 'customJS' ) } ) // Only run on changed files
+	return gulp.src( config.jsCustomSRC, {since: gulp.lastRun( 'customJS' ) } ) // Only run on changed files.
 		.pipe(
 	 		babel({
 				presets: [

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,6 +58,8 @@ var browserSync = require( 'browser-sync' ).create(); // Reloads browser and inj
 var wpPot = require( 'gulp-wp-pot' ); // For generating the .pot file.
 var sort = require( 'gulp-sort' ); // Recommended to prevent unnecessary changes in pot-file.
 var cache = require( 'gulp-cache' ); // Cache files in stream for later use
+var remember = require( 'gulp-remember' ); //  Adds all the files it has ever seen back into the stream
+
 
 /**
  * Task: `browser-sync`.
@@ -152,8 +154,9 @@ gulp.task( 'styles', function() {
  *     3. Renames the JS file with suffix .min.js
  *     4. Uglifes/Minifies the JS file and generates vendors.min.js
  */
+
 gulp.task( 'vendorsJS', function() {
-	return gulp.src( config.jsVendorSRC )
+	return gulp.src( config.jsVendorSRC, {since: gulp.lastRun( 'vendorsJS' ) } )
 		.pipe(
 			babel({
 				presets: [
@@ -165,6 +168,7 @@ gulp.task( 'vendorsJS', function() {
 				]
 			})
 		)
+		.pipe( remember( 'vendorsJS' ) ) // Bring all files back to stream
 		.pipe( concat( config.jsVendorFile + '.js' ) )
 		.pipe( lineec() ) // Consistent Line Endings for non UNIX systems.
 		.pipe( gulp.dest( config.jsVendorDestination ) )

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gulp-line-ending-corrector": "^1.0.1",
     "gulp-merge-media-queries": "^0.2.1",
     "gulp-notify": "^3.0.0",
+    "gulp-remember": "^1.0.1",
     "gulp-rename": "^1.2.0",
     "gulp-sass": "^3.1.0",
     "gulp-sort": "^2.0.0",


### PR DESCRIPTION
<!-- Make the Pull Requests against v2.0.0 branch if possible -->
<!-- Start the commit message/title only with these three words -->
 <!-- "FIX: ", "NEW: ", "IMPROVE: " — all caps (only the first word and not the rest of the title). -->
## Description <!-- Kindly describe your changes -->
This PR adds caching to the `customJS` and `vendorJS` tasks. This is done through the use of Gulp 4's `gulp.lastRun` and the `gulp-remember` plugin. 

On the first run, `gulp.lastRun` will capture all files. `gulp-remember` will also remember all files.

On subsequent runs, `gulp.lastRun` will only capture files that have changed since the last time the task was run. On these runs, `gulp-remember` only remembers files that are not part of the current stream and injects them into the current stream.

## Screenshots: <!-- JPEG or GIFs are always helpful -->
![screen shot 2018-01-14 at 7 44 36 pm](https://user-images.githubusercontent.com/6110968/34924930-725bd00c-f963-11e7-8c3d-499ef35550d7.png)
![screen shot 2018-01-14 at 7 45 00 pm](https://user-images.githubusercontent.com/6110968/34924933-73ef641a-f963-11e7-9f5c-2f43c70dac19.png)

## Types of changes
- NEW: Adds caching functionality to JS tasks, making the tasks run faster as only changed files are processed

## How Has This Been Tested?
I would love for others to test, just to make sure I'm not overlooking anything.

To test this functionality, I temporarily installed `jsHint`, which allowed me to see exactly which files were being processed through the stream. As expected, only changed files are ran through the stream, then `gulp-remember` injects the rest of the files into the stream before they are concatenated. 

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has extensive inline documentation like the rest of WPGulp.