### PR TITLE
NEW: Add gulp-plumber to avoid stream crashes on error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -201,10 +201,10 @@ gulp.task( 'vendorsJS', function() {
  */
 gulp.task( 'customJS', function() {
 	return gulp.src( config.jsCustomSRC, {since: gulp.lastRun( 'customJS' ) } ) // Only run on changed files.        
-        .pipe(plumber({ errorHandler: function(err) {
-            notify.onError("Error: <%= error.message %>")(err);
-            this.emit('end'); // End stream if error is found
-        }}))
+        .pipe( plumber( { errorHandler: function( err ) {
+            notify.onError( 'Error: <%= error.message %>' )( err );
+            this.emit( 'end' ); // End stream if error is found
+        } } ) )
 		.pipe(
 	 		babel({
 				presets: [

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,6 +59,8 @@ var wpPot = require( 'gulp-wp-pot' ); // For generating the .pot file.
 var sort = require( 'gulp-sort' ); // Recommended to prevent unnecessary changes in pot-file.
 var cache = require( 'gulp-cache' ); // Cache files in stream for later use
 var remember = require( 'gulp-remember' ); //  Adds all the files it has ever seen back into the stream
+var plumber = require('gulp-plumber'); // Prevent pipe breaking caused by errors from gulp plugins
+
 
 /**
  * Task: `browser-sync`.
@@ -155,6 +157,10 @@ gulp.task( 'styles', function() {
  */
 gulp.task( 'vendorsJS', function() {
 	return gulp.src( config.jsVendorSRC, {since: gulp.lastRun( 'vendorsJS' ) } ) // Only run on changed files.
+	    .pipe(plumber({ errorHandler: function(err) {
+            notify.onError("Error: <%= error.message %>")(err);
+            this.emit('end'); // End stream if error is found
+        }}))
 		.pipe(
 			babel({
 				presets: [
@@ -194,7 +200,11 @@ gulp.task( 'vendorsJS', function() {
  *     4. Uglifes/Minifies the JS file and generates custom.min.js
  */
 gulp.task( 'customJS', function() {
-	return gulp.src( config.jsCustomSRC, {since: gulp.lastRun( 'customJS' ) } ) // Only run on changed files.
+	return gulp.src( config.jsCustomSRC, {since: gulp.lastRun( 'customJS' ) } ) // Only run on changed files.        
+        .pipe(plumber({ errorHandler: function(err) {
+            notify.onError("Error: <%= error.message %>")(err);
+            this.emit('end'); // End stream if error is found
+        }}))
 		.pipe(
 	 		babel({
 				presets: [

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gulp-line-ending-corrector": "^1.0.1",
     "gulp-merge-media-queries": "^0.2.1",
     "gulp-notify": "^3.0.0",
+    "gulp-plumber": "^1.2.0",
     "gulp-remember": "^1.0.1",
     "gulp-rename": "^1.2.0",
     "gulp-sass": "^3.1.0",


### PR DESCRIPTION
<!-- Make the Pull Requests against v2.0.0 branch if possible -->
<!-- Start the commit message/title only with these three words -->
 <!-- "FIX: ", "NEW: ", "IMPROVE: " — all caps (only the first word and not the rest of the title). -->
## Description <!-- Kindly describe your changes -->
This PR adds gulp-plumber to JS tasks to keep the watch task from crashing on errors. We then use `gulp.notify` (which was already a dependency) to let the user know of the error. If an error is noticed, the current task immediately ends. 

The styles task does not break the stream on errors, so gulp-plumber was not necessary. 

## Screenshots: <!-- JPEG or GIFs are always helpful -->
![screen shot 2018-01-26 at 8 18 19 pm](https://user-images.githubusercontent.com/6110968/35468171-1eaff830-02d6-11e8-9a20-d5b9cd7c2c05.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- FIX: (A change which fixes an issue?) -->
<!-- NEW: (A change which adds new functionality?) -->
<!-- IMPROVE: (A change which improves a functionality?) -->
NEW: Adds gulp-plumber as a dependency.
NEW: Adds gulp-plumber to both JS tasks.

## How Has This Been Tested?
Ran watch tasks and then inserted breaking changes into JS code. 

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has extensive inline documentation like the rest of WPGulp.