### PR TITLE
Add styleDestination to pipe(filter) in style task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -188,7 +188,7 @@ gulp.task( 'browser-sync', function() {
     .pipe( lineec() ) // Consistent Line Endings for non UNIX systems.
     .pipe( gulp.dest( styleDestination ) )
 
-    .pipe( filter( '**/*.css' ) ) // Filtering stream to only css files
+    .pipe( filter( styleDestination + '**/*.css' ) ) // Filtering stream to only css files
     .pipe( mmq( { log: true } ) ) // Merge Media Queries only for .min.css version.
 
     .pipe( browserSync.stream() ) // Reloads style.css if that is enqueued.


### PR DESCRIPTION
Adding styleDestination to .pipe(filter) in the styles task to prevent browserSync force reload when working in remote folders.


## Types of changes
FIX: reload browsersync properly when working with remoteFolders.


## How Has This Been Tested?
In a local environment using WPGulp to modify the behaviour of remote folders.

## Checklist:
- [YES] My code is tested.
- [YES] My code follows the WordPress code style.
- [---] My code follows has extensive inline documentation like the rest of WPGulp.