### PR TITLE
📦 NEW: Compile multiple CSS files into different directories

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -35,12 +35,15 @@
     "gulp-sourcemaps": "^2.6.2",
     "gulp-uglify": "^3.0.0",
     "gulp-uglifycss": "^1.0.6",
-    "gulp-wp-pot": "^2.0.7"
+    "gulp-wp-pot": "^2.0.7",
+    "merge-stream": "^1.0.1"
   },
   "scripts": {
     "start": "gulp",
     "styles": "gulp styles",
+    "addonStyles": "gulp addonStyles",
     "stylesRTL": "gulp stylesRTL",
+    "addonStylesRTL": "gulp addonStylesRTL",
     "vendorsJS": "gulp vendorsJS",
     "customJS": "gulp customJS",
     "images": "gulp images",

--- a/src/wpgulp.config.js
+++ b/src/wpgulp.config.js
@@ -22,6 +22,15 @@ module.exports = {
 	errLogToConsole: true,
 	precision: 10,
 
+	// Add-on Style options
+	// The following list is a set of SCSS/CSS files which you want to process and place it on a different folder.
+	addonStyles: [
+		{
+			styleSRC: './assets/css/addon.scss', // Path to .scss file.
+			styleDestination: './', // Path to place the compiled CSS file. Default set to root folder.
+		},
+	],
+
 	// JS Vendor options.
 	jsVendorSRC: './assets/js/vendor/*.js', // Path to JS vendor folder.
 	jsVendorDestination: './assets/js/', // Path to place the compiled JS vendors file.


### PR DESCRIPTION
<!-- Make the Pull Requests against v2.0.0 branch if possible -->
<!-- Start the commit message/title only with these three words -->
 <!-- "FIX: ", "NEW: ", "IMPROVE: " — all caps (only the first word and not the rest of the title). -->
## Description <!-- Kindly describe your changes -->
Refer to #103 Add capability to compile multiple CSS files into different directories
With this feature, user can add scss files and specify the location of compiled css file for each scss file.
The steps of compilation and configuration is the same as task "styles" and "stylesRTL".
The new task "addonStyles" will be processed with "config.watchStyles"

## Screenshots: <!-- JPEG or GIFs are always helpful -->
No.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- FIX: (A change which fixes an issue?) -->
<!-- NEW: (A change which adds new functionality?) -->
<!-- IMPROVE: (A change which improves a functionality?) -->
NEW: Compile multiple CSS files into different directories

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Tested with the default configuration
Empty configuration "addonStyles" will not bug the task.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has extensive inline documentation like the rest of WPGulp.