### PR TITLE
🚀 FIX: gulp dependencies in package.json

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -16,7 +16,7 @@
     "browser-sync": "^2.11.1",
     "eslint": "^5.5.0",
     "eslint-config-wordpress": "^2.0.0",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "^4.0.0",
     "gulp-autoprefixer": "^6.0.0",
     "gulp-babel": "^8.0.0",
     "gulp-cache": "^1.0.2",


### PR DESCRIPTION
## Description
Fixed issue #128 by replacing "gulp": "github:gulpjs/gulp#4.0" with "gulp": "^4.0.0" in package.json

## Screenshots:
![screenshot 2018-10-23 12 58 33](https://user-images.githubusercontent.com/41078035/47377493-6b2edc00-d6c3-11e8-9c6b-5a83fac3584d.png)

## Types of changes
FIX

## How Has This Been Tested?
Tested by me locally on an active project.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has extensive inline documentation like the rest of WPGulp.