### PR TITLE
IMPROVE: Allowing images inside folders inside /raw to be optimized as well

### DIFF
--- a/src/wpgulp.config.js
+++ b/src/wpgulp.config.js
@@ -33,7 +33,7 @@ module.exports = {
 	jsCustomFile: 'custom', // Compiled JS custom file name. Default set to custom i.e. custom.js.
 
 	// Images options.
-	imgSRC: './assets/img/raw/*', // Source folder of images which should be optimized and watched. You can also specify types e.g. raw/**.{png,jpg,gif} in the glob.
+	imgSRC: './assets/img/raw/**/*', // Source folder of images which should be optimized and watched. You can also specify types e.g. raw/**.{png,jpg,gif} in the glob.
 	imgDST: './assets/img/', // Destination folder of optimized images. Must be different from the imagesSRC folder.
 
 	// Watch files paths.


### PR DESCRIPTION
## Description
I added a wildcard folder selector into the imgSRC attribute so that images within folder inside of the /img/raw directory would be optimized and spit out to the /img folder.

## Screenshots:
None.


## Types of changes
IMPROVE: A tiny change to the imgSRC attribute in wpgulp.config.js to grab folders and images within those folders. This is much the same as the current selector on the watchStyles attribute. I believe this is more intuitive and should be on by default. :)


## How Has This Been Tested?
My own WordPress theme has folders inside the /raw folder called /favicons and /footer. I implemented this change and it works for my theme.


## Checklist:
- [ x ] My code is tested.
- [ x ] My code follows the WordPress code style.
- [ x ] My code follows has extensive inline documentation like the rest of WPGulp.