### PR TITLE
IMPROVE: Gulp API

### DIFF
--- a/src/gulpfile.babel.js
+++ b/src/gulpfile.babel.js
@@ -112,7 +112,7 @@ const reload = done => {
  *    6. Minifies the CSS file and generates style.min.css
  *    7. Injects CSS or reloads the browser via browserSync
  */
-gulp.task( 'styles', () => {
+exports.styles = () => {
 	return gulp
 		.src( config.styleSRC, { allowEmpty: true })
 		.pipe( plumber( errorHandler ) )
@@ -141,7 +141,7 @@ gulp.task( 'styles', () => {
 		.pipe( filter( '**/*.css' ) ) // Filtering stream to only css files.
 		.pipe( browserSync.stream() ) // Reloads style.min.css if that is enqueued.
 		.pipe( notify({ message: '\n\n✅  ===> STYLES — completed!\n', onLast: true }) );
-});
+};
 
 /**
  * Task: `stylesRTL`.
@@ -158,7 +158,7 @@ gulp.task( 'styles', () => {
  *    8. Minifies the CSS file and generates style-rtl.min.css
  *    9. Injects CSS or reloads the browser via browserSync
  */
-gulp.task( 'stylesRTL', () => {
+exports.stylesRTL = () => {
 	return gulp
 		.src( config.styleSRC, { allowEmpty: true })
 		.pipe( plumber( errorHandler ) )
@@ -189,7 +189,7 @@ gulp.task( 'stylesRTL', () => {
 		.pipe( filter( '**/*.css' ) ) // Filtering stream to only css files.
 		.pipe( browserSync.stream() ) // Reloads style.css or style-rtl.css, if that is enqueued.
 		.pipe( notify({ message: '\n\n✅  ===> STYLES RTL — completed!\n', onLast: true }) );
-});
+};
 
 /**
  * Task: `vendorsJS`.
@@ -202,7 +202,7 @@ gulp.task( 'stylesRTL', () => {
  *     3. Renames the JS file with suffix .min.js
  *     4. Uglifes/Minifies the JS file and generates vendors.min.js
  */
-gulp.task( 'vendorsJS', () => {
+exports.vendorsJS = () => {
 	return gulp
 		.src( config.jsVendorSRC, { since: gulp.lastRun( 'vendorsJS' ) }) // Only run on changed files.
 		.pipe( plumber( errorHandler ) )
@@ -232,7 +232,7 @@ gulp.task( 'vendorsJS', () => {
 		.pipe( lineec() ) // Consistent Line Endings for non UNIX systems.
 		.pipe( gulp.dest( config.jsVendorDestination ) )
 		.pipe( notify({ message: '\n\n✅  ===> VENDOR JS — completed!\n', onLast: true }) );
-});
+};
 
 /**
  * Task: `customJS`.
@@ -245,7 +245,7 @@ gulp.task( 'vendorsJS', () => {
  *     3. Renames the JS file with suffix .min.js
  *     4. Uglifes/Minifies the JS file and generates custom.min.js
  */
-gulp.task( 'customJS', () => {
+exports.customJS = () => {
 	return gulp
 		.src( config.jsCustomSRC, { since: gulp.lastRun( 'customJS' ) }) // Only run on changed files.
 		.pipe( plumber( errorHandler ) )
@@ -275,7 +275,7 @@ gulp.task( 'customJS', () => {
 		.pipe( lineec() ) // Consistent Line Endings for non UNIX systems.
 		.pipe( gulp.dest( config.jsCustomDestination ) )
 		.pipe( notify({ message: '\n\n✅  ===> CUSTOM JS — completed!\n', onLast: true }) );
-});
+};
 
 /**
  * Task: `images`.
@@ -293,7 +293,7 @@ gulp.task( 'customJS', () => {
  * Read the following to change these options.
  * @link https://github.com/sindresorhus/gulp-imagemin
  */
-gulp.task( 'images', () => {
+exports.images = () => {
 	return gulp
 		.src( config.imgSRC )
 		.pipe(
@@ -310,7 +310,7 @@ gulp.task( 'images', () => {
 		)
 		.pipe( gulp.dest( config.imgDST ) )
 		.pipe( notify({ message: '\n\n✅  ===> IMAGES — completed!\n', onLast: true }) );
-});
+};
 
 /**
  * Task: `clear-images-cache`.
@@ -318,9 +318,9 @@ gulp.task( 'images', () => {
  * Deletes the images cache. By running the next "images" task,
  * each image will be regenerated.
  */
-gulp.task( 'clearCache', function( done ) {
+exports.clearCache = function( done ) {
 	return cache.clearAll( done );
-});
+};
 
 /**
  * WP POT Translation File Generator.
@@ -331,7 +331,7 @@ gulp.task( 'clearCache', function( done ) {
  * 3. Applies wpPot with the variable set at the top of this file
  * 4. Generate a .pot file of i18n that can be used for l10n to build .mo file
  */
-gulp.task( 'translate', () => {
+exports.translate = () => {
 	return gulp
 		.src( config.watchPhp )
 		.pipe( sort() )
@@ -346,20 +346,17 @@ gulp.task( 'translate', () => {
 		)
 		.pipe( gulp.dest( config.translationDestination + '/' + config.translationFile ) )
 		.pipe( notify({ message: '\n\n✅  ===> TRANSLATE — completed!\n', onLast: true }) );
-});
+};
 
 /**
  * Watch Tasks.
  *
  * Watches for file changes and runs specific tasks.
  */
-gulp.task(
-	'default',
-	gulp.parallel( 'styles', 'vendorsJS', 'customJS', 'images', browsersync, () => {
-		gulp.watch( config.watchPhp, reload ); // Reload on PHP file changes.
-		gulp.watch( config.watchStyles, gulp.parallel( 'styles' ) ); // Reload on SCSS file changes.
-		gulp.watch( config.watchJsVendor, gulp.series( 'vendorsJS', reload ) ); // Reload on vendorsJS file changes.
-		gulp.watch( config.watchJsCustom, gulp.series( 'customJS', reload ) ); // Reload on customJS file changes.
-		gulp.watch( config.imgSRC, gulp.series( 'images', reload ) ); // Reload on customJS file changes.
-	})
-);
+exports.default = gulp.parallel( 'styles', 'vendorsJS', 'customJS', 'images', browsersync, () => {
+	gulp.watch( config.watchPhp, reload ); // Reload on PHP file changes.
+	gulp.watch( config.watchStyles, gulp.parallel( 'styles' ) ); // Reload on SCSS file changes.
+	gulp.watch( config.watchJsVendor, gulp.series( 'vendorsJS', reload ) ); // Reload on vendorsJS file changes.
+	gulp.watch( config.watchJsCustom, gulp.series( 'customJS', reload ) ); // Reload on customJS file changes.
+	gulp.watch( config.imgSRC, gulp.series( 'images', reload ) ); // Reload on customJS file changes.
+});


### PR DESCRIPTION
As the official Gulp [documentation](https://gulpjs.com/docs/en/api/task) says about `gulp.task()` API:

> Reminder: This API isn't the recommended pattern anymore - export your tasks.

This PR simply does that.

## Types of changes
Replaced `gulp.task()` with exports API.

## How Has This Been Tested?
Tested the changed file with an actual plugin development environment.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has extensive inline documentation like the rest of WPGulp.